### PR TITLE
github -> GitHub and a typo fix

### DIFF
--- a/00-about.md
+++ b/00-about.md
@@ -28,7 +28,7 @@ and encourages the explicit replication of already published research,
 promoting new and open-source implementations in order to ensure that the
 original research is reproducible. To achieve this goal, the whole publishing
 chain is radically different from any other traditional scientific
-journal. Re**Science** lives on [github](https://github.com/ReScience/) where
+journal. Re**Science** lives on [GitHub](https://github.com/ReScience/) where
 each new implementation of a computational study is made available together with comments, explanations
 and tests. Each submission takes the form of a pull request that is publicly
 reviewed and tested in order to guarantee that any researcher can re-use it. If

--- a/02-write.md
+++ b/02-write.md
@@ -7,7 +7,7 @@ permalink: /write/
 # Overview of the submission process
 
 The Re**Science** editorial board unites scientists who are committed to the
-open source community. They are experienced developpers who are
+open source community. They are experienced developers who are
 familiar with the GitHub ecosystem. Each editorial board member is specialised
 in a specific domain of science and is proficient in several programming
 languages and/or environments. Our aim is to provide all authors with an
@@ -52,7 +52,7 @@ from the authors or the publishers.
 
 ## How to submit ?
 
-* Create a [github](https://github.com) account
+* Create a [GitHub](https://github.com) account
 * [Fork](https://github.com/ReScience/ReScience-submission/fork) the
   [ReScience submission](https://github.com/ReScience/ReScience-submission)
   repository
@@ -71,7 +71,7 @@ from the authors or the publishers.
   ```
   $ git commit -a -m "Some comment"
   ```
-* [Push](https://help.github.com/articles/pushing-to-a-remote/) to github
+* [Push](https://help.github.com/articles/pushing-to-a-remote/) to GitHub
 
   ```
   $ git push origin AUTHOR1-AUTHOR2-...-AUTHORN-YEAR
@@ -135,4 +135,3 @@ The structure of a submission is:
 * A `code` directory that contains the **commented** code for the replication.
 * A `data` directory that contains any data necessary to run the code.
 * A `notebook` directory that may contain notebooks if relevant.
-

--- a/03-edit.md
+++ b/03-edit.md
@@ -9,10 +9,10 @@ permalink: /edit/
 
 A submission takes the form of a
 [Pull Request](https://help.github.com/articles/using-pull-requests/) which is
-a mechanism in github to request the integration of some code into a
+a mechanism in GitHub to request the integration of some code into a
 repository. We use this mechanism as the primary source for the review because
 it allows to precisely comment each source and to exchange with the author. If
-you're unfamiliar with github, do not hesitate to ask advices and informations
+you're unfamiliar with GitHub, do not hesitate to ask advices and informations
 to the editor in charge of editing the submission. You can have a look at what
 a full [submission](https://github.com/ReScience/ReScience-submission/pull/3)
 looks like.
@@ -91,7 +91,7 @@ like.
   * [ ] Editor decision [accept/reject]
   ```
 
-   You'll need to ask reviewers to add their github login after `review 1
+   You'll need to ask reviewers to add their GitHub login after `review 1
    started` or `review 2 started`.  For example `review 1 started (@rougier)`
 
 * During the review, reviewers are free to interact with the authors in the PR to ask for

--- a/04-board.md
+++ b/04-board.md
@@ -8,9 +8,9 @@ permalink: /board/
 
 The editorial board is made of people who are committed to the open source
 community and are both experienced developper and strongly familiar with the
-github ecosystem. Each editorial board member is specialised in a specific
+GitHub ecosystem. Each editorial board member is specialised in a specific
 domain of Science and is proficient in several programming languages and/or
-environments. While many of us work primarily in Python, ReScience also 
+environments. While many of us work primarily in Python, ReScience also
 accepts submissions in other open source languages.
 
 

--- a/05-FAQ.md
+++ b/05-FAQ.md
@@ -18,7 +18,7 @@ Yes ! You can:
  * [Submit](../write) paper for the work you've already replicated
  * Spread the word about Re**Science** in your community
    ([twitter](http://twitter.com/ReScienceEds), mailing lists, blogs, etc.)
- * [Star the project](https://github.com/ReScience/ReScience) on github
+ * [Star the project](https://github.com/ReScience/ReScience) on GitHub
  * Help improving this website by
    [forking it](https://github.com/ReScience/rescience.github.io/fork) and
    propose modifications (through PR)
@@ -35,7 +35,7 @@ Yes ! You can:
 ## Are there any publication fees ?
 
 No. Re**Science** promotes open access and relies on the volunteer work of
-editors and reviewers. And the free hosting by github.
+editors and reviewers. And the free hosting by GitHub.
 
 
 ## Can I submit a paper using proprietary tools such as Matlab ?

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ http://rescience.github.io
 bundle exec jekyll serve
 ```
 
-### Force rebuild on github
+### Force rebuild on GitHub
 ```
 bundle exec htmlproof ./_site --only-4xx --check-favicon --check-html
 ```

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ and encourages the explicit replication of already published research,
 promoting new and open-source implementations in order to ensure that the
 original research is reproducible. To achieve this goal, the whole publishing
 chain is radically different from other traditional scientific
-journals. Re**Science** lives on [github](https://github.com/ReScience/) where
+journals. Re**Science** lives on [GitHub](https://github.com/ReScience/) where
 each new implementation of a computational study is made available together with comments, explanations
 and tests. Each submission takes the form of a pull request that is publicly
 reviewed and tested in order to guarantee that any researcher can re-use it. If


### PR DESCRIPTION
This Pull Request does two things:

0. Changes all instances of `github` to `GitHub` (given your journal name I'm assuming you'll be sympathetic to this :smile_cat:)
0. Fixes a minor typo