### PR TITLE
Improve navigation from the home page.

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,13 +19,13 @@ you ever replicated computational results from the literature in your research,
 Re**Science** is the perfect place to publish your new implementation.
 
 Re**Science** is collaborative by design. Everything can be forked and
-modified. Don't hesitate to [join us](faq) and
+modified. Don't hesitate to [write a submission](write), [join us](faq) and
 to [become a reviewer](https://github.com/ReScience/ReScience/issues/27).
 
 
 ### Current activity
 
-Published articles: 17  
+Published articles: [17](https://github.com/ReScience/ReScience)  
 Submitted articles awaiting review: 0  
 Articles currently under review: 6 ([#39], [#41], [#43], [#45], [#46], [#47])  
 Articles awaiting publication: 0  


### PR DESCRIPTION
Add links to the submission instructions and the archive of published issues of the journal.

Note that the /read page could also be improved by adding links to past issues but I am not sure how the rendering of that page works.

Furthermore, the "Latest News" section of the homepage should include direct links at least to the PDF and maybe the full list of links Links: "PDF | Code repository | Review | DOI XX.YYYY/zenodo.XXXXXX" but I don't know how the template system works.