### PR TITLE
Update URL for the call for replication

### DIFF
--- a/05-FAQ.md
+++ b/05-FAQ.md
@@ -96,8 +96,8 @@ effort.
 ## Can I suggest a replication?
 
 Yes. If you want to suggest an article for a replication, just [open a new
-issue](https://github.com/rescience/call/issues/new) in the [call for
-replication repository](https://github.com/rescience/call) and give the
+issue](https://github.com/ReScience/call-for-replication/issues/new) in the [call for
+replication repository](https://github.com/ReScience/call-for-replication) and give the
 reference of the original article and possibly the reason you would like to see
 this article replicated (please refrain from suggesting your own work). Note
 that you're also encouraged to register as a reviewer such that you can review
@@ -105,7 +105,7 @@ the replication you've been proposing if someone actually takes up the
 challenge.
 
 If you're looking for some challenge, you can also look at the [current list of
-suggestions](https://github.com/rescience/call).
+suggestions](https://github.com/ReScience/call-for-replication).
 
 
 ## If my submission is rejected, can I resubmit it?


### PR DESCRIPTION
https://github.com/ReScience/call moved to https://github.com/ReScience/call-for-replication

Closes #62. 