### PR TITLE
avoid blank lines in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,11 +16,7 @@
       </a>
 
       <div class="trigger">
-        {% for page in site.pages %}
-          {% if page.menutitle %}
-          <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.menutitle }}</a>
-          {% endif %}
-        {% endfor %}
+        {% for page in site.pages %}{% if page.menutitle %}<a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.menutitle }}</a>{% endif %}{% endfor %}
       </div>
     </nav>
 


### PR DESCRIPTION
With the old versions, the number of blank lines depends on the total number of files in the website.

fix #89 