### PR TITLE
add 10.5281/zenodo.6546488 Picoche et al 2022

### DIFF
--- a/_bibliography/published.bib
+++ b/_bibliography/published.bib
@@ -2576,3 +2576,25 @@
   keywords =     {rescience c, rescience x}
 }
 
+@Article {Picoche:2022,
+  author =       {Coralie Picoche and William R. Young and Frederic Barraquand},
+  title =        {{[Re] Reproductive pair correlations and the clustering of organisms}},
+  journal =      {ReScience C},
+  year =         {2022},
+  month =        {5},
+  volume =       {8},
+  number =       {1},
+  pages =        {{#3}},
+  doi =          {10.5281/zenodo.6546488},
+  url =          {https://zenodo.org/record/6546488/files/article.pdf},
+  code_url =     {https://github.com/CoraliePicoche/brownian_bug_fluid/tree/main/code},
+  code_doi =     {10.5281/zenodo.6546471},
+  code_swh =     {},
+  data_url =     {},
+  data_doi =     {},
+  review_url =   {https://github.com/ReScience/submissions/issues/58},
+  type =         {Replication},
+  language =     {C++},
+  domain =       {Ecology},
+  keywords =     {phytoplankton, individual-based model, clustering, advection-diffusion-reaction, C++}
+}


### PR DESCRIPTION
See https://github.com/ReScience/articles/pull/26