### PR TITLE
NEW: adding GH action to auto-deploy website updates

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,26 @@
+name: Publishing website updates
+
+on:
+  push:
+    branches:
+      - sources
+
+jobs:
+  jekyll:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Use GitHub Actions' cache to shorten build times and decrease load on servers
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    # Specify the target branch (optional)
+    - uses: helaili/jekyll-action@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        target_branch: 'master'


### PR DESCRIPTION
Hello there, 

I am running another journal, [JSys](jsys.org), for which I heavily reused the RescienceC website code. Thanks for having it open! 

I just setup a github action for our website to auto-deploy the website updates (rather than having to run the `publish.sh` script). 

Feel free to merge if you like the feature :-) 